### PR TITLE
Export metrics for each EOL status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ aws_custom_rds_cluster_count{cluster_identifier="video-production-a",engine="aur
 aws_custom_rds_cluster_count{cluster_identifier="video-staging-a",engine="aurora-postgresql",engine_version="9.6.17",eol_status="ok"} 1
 ```
 
+|metric|description|tags|note|
+|---------------------------------|-----------------------------------------------|--------------------------------------------------------------|----------|
+|aws_custom_rds_eol_status_ok     |Number of instances whose EOL status is ok     |"cluster_identifier", "engine", "engine_version"              |          |
+|aws_custom_rds_eol_status_alert  |Number of instances whose EOL status is alert  |"cluster_identifier", "engine", "engine_version"              |          |
+|aws_custom_rds_eol_status_warning|Number of instances whose EOL status is warning|"cluster_identifier", "engine", "engine_version"              |          |
+|aws_custom_rds_eol_status_expired|Number of instances whose EOL status is expired|"cluster_identifier", "engine", "engine_version"              |          |
+|aws_custom_rds_cluster_count     |Number of RDS                                  |"cluster_identifier", "engine", "engine_version", "eol_status"|DEPRECATED|
+
 ## IAM Role
 
 The following policy must be attached to the AWS role to be executed.

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.37.11 h1:W1gUQxt6jmiUsk2jkTVAlYsd3Sg8bNL2VDcWjrXmD+0=
 github.com/aws/aws-sdk-go v1.37.11/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
In metric managing system, need "0" value for each metrics.
For example, if EOL status of an RDS instance is ok,
there are no metrics that have eol_status:warning(also expired and alert).

In the case, metric managing system, (i.e. Datadog) detects "No Data".
So I'd like to add a metric for each status.