### PR TITLE
Abondan oracle-se/oracle-se1

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,14 +259,6 @@ func getRDSInstances() ([]RDSInfo, error) {
 			},
 			{
 				Name:   aws.String("engine"),
-				Values: []*string{aws.String("oracle-se1")},
-			},
-			{
-				Name:   aws.String("engine"),
-				Values: []*string{aws.String("oracle-se")},
-			},
-			{
-				Name:   aws.String("engine"),
 				Values: []*string{aws.String("postgres")},
 			},
 			{


### PR DESCRIPTION
It has not supported already.


Error:

```
aws-rds-engine-version-prometheus-exporter-7bc695b466-42lkg aws-rds-engine-version-prometheus-exporter 2021/04/20 09:30:07 failed to read RDS Instance infos: failed to describe DB instances: InvalidParameterValue: Unrecognized engine name: oracle-se1
aws-rds-engine-version-prometheus-exporter-7bc695b466-42lkg aws-rds-engine-version-prometheus-exporter 	status code: 400, request id: e143e790-6ae2-43e3-bd88-38ab92ae078f
```