### PR TITLE
EOL Aurora PostgreSQL v10.11,10.12,11.6,11.7

### DIFF
--- a/minimum_supported_version.csv
+++ b/minimum_supported_version.csv
@@ -3,3 +3,5 @@ mysql,5.7.0,2021-02-05
 postgres,9.6.0,2021-02-16
 postgres,9.7.0,2022-01-18
 aurora-postgresql,10.4,2022-01-31
+aurora-postgresql,10.14,2022-03-16
+aurora-postgresql,11.9,2022-09-21


### PR DESCRIPTION
ref: https://aws.amazon.com/jp/blogs/news/amazon-aurora-postgresql-10-retirement/