### PR TITLE
Make ALERT_HOURS and WARNING_HOURS configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The following policy must be attached to the AWS role to be executed.
 
 ## Environment Variable
 
-|name          |required|default|description                                       |
-|--------------|--------|-------|--------------------------------------------------|
-|ALERT_HOURS   |no      | 2160  | Time to determine "alert" status for EOL dates   |
-|WARNING_HOURS |no      | 4320  | Time to determine "warning" status for EOL dates |
+|name            |required|default|description                                       |
+|----------------|--------|-------|--------------------------------------------------|
+|ALERT_HOURS     |no      | 2160  | Time to determine "alert" status for EOL dates   |
+|WARNING_HOURS   |no      | 4320  | Time to determine "warning" status for EOL dates |
+|AWS_API_INTERVAL|no      | 300   | Interval between calls to the AWS API            |
 
 ## Datadog Autodiscovery
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ The following policy must be attached to the AWS role to be executed.
 }
 ```
 
+## Environment Variable
+
+|name          |required|default|description                                       |
+|--------------|--------|-------|--------------------------------------------------|
+|ALERT_HOURS   |no      | 2160  | Time to determine "alert" status for EOL dates   |
+|WARNING_HOURS |no      | 4320  | Time to determine "warning" status for EOL dates |
+
 ## Datadog Autodiscovery
 
 If you use Datadog, you can use [Kubernetes Integration Autodiscovery](https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes) feature.

--- a/main_test.go
+++ b/main_test.go
@@ -26,10 +26,10 @@ func TestValidateEOLDate(t *testing.T) {
 		{name: "Expired", validDate: "2020-12-31", now: now, out: "expired"},
 		{name: "Alert", validDate: "2021-01-01", now: now, out: "alert"},
 		{name: "Alert", validDate: "2021-01-02", now: now, out: "alert"},
-		{name: "Warning", validDate: "2021-01-30", now: now, out: "alert"},
-		{name: "Warning", validDate: "2021-01-31", now: now, out: "warning"},
-		{name: "Warning", validDate: "2021-03-31", now: now, out: "warning"},
-		{name: "OK", validDate: "2021-04-01", now: now, out: "ok"},
+		{name: "Warning", validDate: "2021-03-30", now: now, out: "alert"},
+		{name: "Warning", validDate: "2021-04-01", now: now, out: "warning"},
+		{name: "Warning", validDate: "2021-06-29", now: now, out: "warning"},
+		{name: "OK", validDate: "2021-06-30", now: now, out: "ok"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I noticed that the default value of warning 90 days alert 30 days is too short.
I also noticed that it is not changeable.